### PR TITLE
Build with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ potato.txt
 stderr.txt
 *_termwidthfile
 *.prof
+tags

--- a/dep/reflex-platform/default.nix
+++ b/dep/reflex-platform/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "reflex-frp",
+  "repo": "reflex-platform",
+  "branch": "fendor/develop+reflex-vty-text-input",
+  "private": false,
+  "rev": "1d2dc0061175cdaa59b5982e771c9ddb6e8619bc",
+  "sha256": "0jrbwlgwga26c8z5p326z4qp96rr0rgmxzh0bc38mw3nlfa1vqzs"
+}

--- a/dep/reflex-platform/thunk.nix
+++ b/dep/reflex-platform/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/reflex-potatoes/default.nix
+++ b/dep/reflex-potatoes/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/reflex-potatoes/github.json
+++ b/dep/reflex-potatoes/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "reflex-potatoes",
+  "branch": "aa/fix-haddock",
+  "private": false,
+  "rev": "239d6e478e5c1579f45b99df3adb12dc9c3d7c1d",
+  "sha256": "0jglf0fdddsv734shrghad6a8pa51bansasw9i0y40p37z0vqpz8"
+}

--- a/dep/reflex-potatoes/thunk.nix
+++ b/dep/reflex-potatoes/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/reflex-test-host/default.nix
+++ b/dep/reflex-test-host/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/reflex-test-host/github.json
+++ b/dep/reflex-test-host/github.json
@@ -1,0 +1,7 @@
+{
+  "owner": "pdlla",
+  "repo": "reflex-test-host",
+  "private": false,
+  "rev": "5f367c2e720cdd588e1dffa34cd8223c310f5f43",
+  "sha256": "0k1njbb9rzrhbzysrawh8hs799w6nsr6ndkc78b0vqqx48c8hhvx"
+}

--- a/dep/reflex-test-host/thunk.nix
+++ b/dep/reflex-test-host/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/dep/tinytools/default.nix
+++ b/dep/tinytools/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/tinytools/github.json
+++ b/dep/tinytools/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "tinytools",
+  "branch": "aa/fix-haddock",
+  "private": false,
+  "rev": "421a84ef2f558413894da13a076d01c6e52fc7eb",
+  "sha256": "02clgbnaaf4f06mxyjlm6f47spy40njkpyj1sqksi411kz6nmp09"
+}

--- a/dep/tinytools/thunk.nix
+++ b/dep/tinytools/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/env.nix
+++ b/env.nix
@@ -1,0 +1,19 @@
+let mkPlatform = import ./dep/reflex-platform;
+    thunkSource = (import ./dep/reflex-platform {}).hackGet;
+    rp = mkPlatform {
+      haskellOverlays = [
+        (self: super: {
+          reflex-potatoes = self.callCabal2nix "reflex-potatoes" (thunkSource ./dep/reflex-potatoes) {};
+          tinytools = self.callCabal2nix "tinytools" (thunkSource ./dep/tinytools) {};
+          reflex-test-host= self.callCabal2nix "reflex-test-host" (thunkSource ./dep/reflex-test-host) {};
+        })
+      ];
+    };
+    src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [
+      "release.nix"
+      "default.nix"
+      ".git"
+      "dist"
+      "dist-newstyle"
+    ])) ./.;
+in { inherit src; ghc = rp.ghc8_10; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+let rp = import ./dep/reflex-platform {};
+    pkgs = rp.nixpkgs;
+    env = import ./env.nix;
+in pkgs.mkShell {
+    name = "tinytools-vty";
+    buildInputs = [
+      pkgs.cabal-install
+      pkgs.ghcid
+    ];
+    inputsFrom = [
+      (env.ghc.callCabal2nix "tinytools-vty" env.src {}).env
+    ];
+  }


### PR DESCRIPTION
You can enter the nix-shell by calling "nix-shell" in the project directory. It uses [nix thunks](https://github.com/obsidiansystems/nix-thunk) instead of submodules. I had to use forks of a couple of the dependencies, but once those PRs are merged, I can switch back to upstream.